### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ def hello():
 ```python
 if __name__ == '__main__':
     multiprocessing.freeze_support()  # For Windows support
-    uvicorn.run(app, host="0.0.0.0", port=8000, reload=False, workers=1)
+    run(app, host="0.0.0.0", port=8000, reload=False, workers=1)
 ```
 
 ## Compiling with PyInstaller


### PR DESCRIPTION
Hi,
we import `from uvicorn import run` so wen can't use `uvicorn.run(app, host="0.0.0.0", port=8000, reload=False, workers=1)` in the main part of the programm, because we don't have `uvicorn.run` imported - only `run`.